### PR TITLE
implements HasSize

### DIFF
--- a/src/main/java/org/vaadin/olli/FileDownloadWrapper.java
+++ b/src/main/java/org/vaadin/olli/FileDownloadWrapper.java
@@ -7,6 +7,7 @@ import java.io.FileNotFoundException;
 import java.io.InputStream;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.html.Anchor;
@@ -17,7 +18,7 @@ import com.vaadin.flow.templatemodel.TemplateModel;
 
 @Tag("file-download-wrapper")
 @HtmlImport("file-download-wrapper.html")
-public class FileDownloadWrapper extends PolymerTemplate<FileDownloadWrapper.FileDownloadWrapperModel> {
+public class FileDownloadWrapper extends PolymerTemplate<FileDownloadWrapper.FileDownloadWrapperModel> implements HasSize {
 
     @Id("download-link")
     protected Anchor anchor;


### PR DESCRIPTION
Hi Olli

This is a great component, but currently one cannot set sizes of the wrapper. Since one has to add the wrapper to the layout and not the wrapped component, the wrapper needs to be resizable in my opinion.

I could make my own class extends FileDownloadWrapper implements HasSize, but I can't use the constructor with parameters `String filename, FileDownloadWrapper.DownloadBytesProvider provider`, because FileDownloadWrapper.DownloadBytesProvider is not public.

Luckily, I myself don't need that constructor anyway in my project, but maybe others do. 

Cheers