### PR TITLE
Update vaadin -> 24.4.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <description>Helper for creating links that allow you to download files.</description>
 
     <properties>
-        <vaadin.version>24.0.0.beta4</vaadin.version>
+        <vaadin.version>24.4.7</vaadin.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This updates Vaadin to `24.4.7`.
The version before was a beta version, that requires maven repositories that are not available for our production builds. 